### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/Sweetpinkrose33/6cf8f4c5-8462-49ff-9bf5-4ba98b8ab6b3/b0ab776d-5a30-4ae8-9c60-d0a5c442c54f/_apis/work/boardbadge/678609f6-5ea5-4090-8627-a96c268c7e21)](https://dev.azure.com/Sweetpinkrose33/6cf8f4c5-8462-49ff-9bf5-4ba98b8ab6b3/_boards/board/t/b0ab776d-5a30-4ae8-9c60-d0a5c442c54f/Microsoft.RequirementCategory)
 # Your GitHub Learning Lab Repository for Introducing GitHub
 
 Welcome to **your** repository for your GitHub Learning Lab course. This repository will be used during the different activities that I will be guiding you through. See a word you don't understand? We've included an emoji 📖 next to some key terms. Click on it to see its definition.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/Sweetpinkrose33/6cf8f4c5-8462-49ff-9bf5-4ba98b8ab6b3/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.